### PR TITLE
Switch to 40 character APT key

### DIFF
--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -37,7 +37,7 @@ class nginx::package::debian(
         apt::source { 'nginx':
           location   => "http://nginx.org/packages/${distro}",
           repos      => 'nginx',
-          key        => '7BD9BF62',
+          key        => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62',
           key_source => 'http://nginx.org/keys/nginx_signing.key',
           notify     => Exec['apt_get_update_for_nginx'],
         }

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -62,7 +62,7 @@ describe 'nginx::package' do
       it { is_expected.to contain_apt__source('nginx').with(
         'location'   => "http://nginx.org/packages/#{operatingsystem}",
         'repos'      => 'nginx',
-        'key'        => '7BD9BF62',
+        'key'        => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62',
         'key_source' => 'http://nginx.org/keys/nginx_signing.key'
       )}
       it { is_expected.to contain_anchor('nginx::package::begin').that_comes_before('Class[nginx::package::debian]') }


### PR DESCRIPTION
It improves security and keeps Puppet from complaining. Trivially tested and working.
