### PR TITLE
update concat module, remove ensure in fragment resources

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -343,7 +343,6 @@ define nginx::resource::location (
     $tmpFile=md5("${vhost_sanitized}-${priority}-${location_sanitized}")
 
     concat::fragment { $tmpFile:
-      ensure  => present,
       target  => $config_file,
       content => join([
         template('nginx/vhost/location_header.erb'),
@@ -360,7 +359,6 @@ define nginx::resource::location (
 
     $sslTmpFile=md5("${vhost_sanitized}-${ssl_priority}-${location_sanitized}-ssl")
     concat::fragment { $sslTmpFile:
-      ensure  => present,
       target  => $config_file,
       content => join([
         template('nginx/vhost/location_header.erb'),

--- a/manifests/resource/mailhost.pp
+++ b/manifests/resource/mailhost.pp
@@ -130,7 +130,6 @@ define nginx::resource::mailhost (
 
   if ($listen_port != $ssl_port) {
     concat::fragment { "${name}-header":
-      ensure  => present,
       target  => $config_file,
       content => template('nginx/mailhost/mailhost.erb'),
       order   => '001',
@@ -140,7 +139,6 @@ define nginx::resource::mailhost (
   # Create SSL File Stubs if SSL is enabled
   if ($ssl) {
     concat::fragment { "${name}-ssl":
-      ensure  => present,
       target  => $config_file,
       content => template('nginx/mailhost/mailhost_ssl.erb'),
       order   => '700',

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -546,7 +546,6 @@ define nginx::resource::vhost (
 
   if ($listen_port != $ssl_port) {
     concat::fragment { "${name_sanitized}-header":
-      ensure  => present,
       target  => $config_file,
       content => template('nginx/vhost/vhost_header.erb'),
       order   => '001',
@@ -556,7 +555,6 @@ define nginx::resource::vhost (
   # Create a proper file close stub.
   if ($listen_port != $ssl_port) {
     concat::fragment { "${name_sanitized}-footer":
-      ensure  => present,
       target  => $config_file,
       content => template('nginx/vhost/vhost_footer.erb'),
       order   => '699',

--- a/metadata.json
+++ b/metadata.json
@@ -11,6 +11,6 @@
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 3.0.0"},
     {"name":"puppetlabs/apt","version_requirement":">= 2.0.0"},
-    {"name":"puppetlabs/concat","version_requirement":">= 1.1.0"}
+    {"name":"puppetlabs/concat","version_requirement":">= 4.2.1"}
   ]
 }


### PR DESCRIPTION
Ensure isn't valid in concat 4 and up for the fragment resources.  This PR removes those and bumps the version requirement for concat 